### PR TITLE
Show publisher if not preprint type

### DIFF
--- a/_layouts/publication.html
+++ b/_layouts/publication.html
@@ -189,7 +189,7 @@ layout: default
           </p>
         </a>
       </li>
-      {% elsif page.bib.doi and page.preprint == nil %}
+      {% elsif page.bib.doi and page.type != "preprint" %}
       <li>
         <a href="https://dx.doi.org/{{ page.bib.doi }}" target="_blank">
           <p>


### PR DESCRIPTION
Link out to publisher if publication is not a preprint.

Used to check if there is a preprint link, which would not show the publisher for papers that still link to the preprint.